### PR TITLE
Fix preprocessing for one-hot encoded cols, fix deploy flicker

### DIFF
--- a/app/frontend/components/ModelDetails.tsx
+++ b/app/frontend/components/ModelDetails.tsx
@@ -37,19 +37,14 @@ export function ModelDetails({ model, onBack, rootPath }: ModelDetailsProps) {
     const deployingRun = runs.find(run => run.is_deploying);
     if (deployingRun) {
       pollInterval = window.setInterval(async () => {
-        const response = await fetch(`${rootPath}/retraining_runs/${deployingRun.id}`, {
-          headers: {
-            'Accept': 'application/json'
-          }
-        });
-        const data = await response.json();
-        
-        if (!data.is_deploying) {
-          window.location.href = window.location.href; // Full page reload when done
-        }
+        router.get(window.location.href, {
+          preserveScroll: true,
+          preserveState: true,
+          only: ['runs']
+        })
       }, 2000);
     }
-
+        
     return () => {
       if (pollInterval) {
         window.clearInterval(pollInterval);

--- a/app/frontend/components/dataset/ColumnFilters.tsx
+++ b/app/frontend/components/dataset/ColumnFilters.tsx
@@ -48,7 +48,6 @@ export function ColumnFilters({
     }
   };
 
-
   const calculateNullPercentage = (column: Column) => {
     if (!column.statistics?.processed?.null_count || !column.statistics?.processed?.num_rows) return 0;
     return (column.statistics.processed.null_count / column.statistics.processed.num_rows) * 100;

--- a/app/frontend/components/dataset/PreprocessingConfig.tsx
+++ b/app/frontend/components/dataset/PreprocessingConfig.tsx
@@ -252,11 +252,11 @@ export function PreprocessingConfig({
 
   let nullCount = (column.statistics?.processed.null_count || column.statistics?.raw.null_count) || 0;
   const nullPercentage = nullCount && column.statistics?.raw.num_rows
-    ? Math.round((nullCount / column.statistics.raw.num_rows) * 100)
+    ? ((nullCount / column.statistics.raw.num_rows) * 100)
     : 0;
 
   const nullPercentageProcessed = column.statistics?.processed?.null_count && column.statistics?.raw.num_rows
-    ? Math.round((column.statistics.processed.null_count / column.statistics.raw.num_rows) * 100)
+    ? ((column.statistics.processed.null_count / column.statistics.raw.num_rows) * 100)
     : 0;
 
   const totalRows = column.statistics?.raw.num_rows ?? 0;

--- a/app/models/easy_ml/dataset.rb
+++ b/app/models/easy_ml/dataset.rb
@@ -289,7 +289,8 @@ module EasyML
 
           if one_hot_cols.include?(column.name)
             base = self.raw
-            processed = stats.dig("raw", column.name)
+            processed = stats.dig("raw", column.name).dup
+            processed["null_count"] = 0
             actual_schema_type = "categorical"
             actual_type = "categorical"
           else

--- a/app/models/easy_ml/retraining_run.rb
+++ b/app/models/easy_ml/retraining_run.rb
@@ -34,7 +34,7 @@ module EasyML
 
     belongs_to :retraining_job
     belongs_to :model, class_name: "EasyML::Model"
-    belongs_to :model_file, class_name: "EasyML::ModelFile"
+    belongs_to :model_file, class_name: "EasyML::ModelFile", optional: true
     has_many :events, as: :eventable, class_name: "EasyML::Event", dependent: :destroy
 
     validates :status, presence: true, inclusion: { in: %w[pending running success failed deployed] }


### PR DESCRIPTION
* Fix rounded statistics on PreprocessingConfig
* Make model_file association optional for retraining runs so they can be created pre-deploy
* Fix flicker on deploy page by moving to proper Inertia setup
* Fix statistics for one-hot encoded columns (which are translated into multiple columns on the processed dataset)